### PR TITLE
Attempt to support encrypted framelengths

### DIFF
--- a/signal_backup_file.py
+++ b/signal_backup_file.py
@@ -79,7 +79,7 @@ class FrameReader:
         bytesleft = length
 
         while (bytesleft != 0):
-            enc_chunk = get_chunk(min(bytesleft, 16 - enc_iv_idx));
+            enc_chunk = get_chunk(min(bytesleft, 16 - enc_iv_idx))
             bytesleft -= len(enc_chunk)
 
             mac.update(enc_chunk)
@@ -125,7 +125,8 @@ class FrameReader:
                     frame_length = int.from_bytes(self.get_framelength(frame_length_b), byteorder='big')
 
                 frame = BackupFrame()
-                frame.ParseFromString(self.read_frame(frame_length - 10, (-1 if self.backup_version == 0 else frame_length_b), False))
+                frame.ParseFromString(self.read_frame(
+                    frame_length - 10, (-1 if self.backup_version == 0 else frame_length_b), False))
 
                 # Read Attachment
                 attachment = None


### PR DESCRIPTION
Since you tagged me in #6, I gave it a go.

I am _NOT_ a python programmer, this is the first python code I've written in well over 20 years (and even then it was 'hello world'-level).

It is probably messy code, and I had to drop at least one design feature (the 'generator'-function `get_chunk`) to get it working, but both may be because I don't speak python, maybe there are better ways to do this. So, feel free to not merge this pull request, it is just to give you an example. You might want to completely rewrite it.

What changed:
The 4 byte frame length is now part of the encrypted frame data (and consequently also part of the MAC). I added a function `get_framelength()` which decrypts the framelength. Then, in `read_frame()`, I update the mac with the encrypted framedata, and make sure the first chunk read is no larger than 12 bytes (instead of 16, because of the 4 byte framelength) and use the `enc_iv` array from an offset of 4 bytes for the first chunk.

It might result in nicer code if the framelength was actually retrieved in `read_frame` somewhere, but I just used what was already there and adjusted as little as I could. But again: not a python programmer.

As far as I can tell, it works.