### PR TITLE
Rewrite read_frame(), use AES_CTR for big speed-up

### DIFF
--- a/signal_backup_file.py
+++ b/signal_backup_file.py
@@ -78,7 +78,7 @@ class FrameReader:
             length = int.from_bytes(frame_length_b, byteorder='big') - 10
 
         if with_iv:
-           mac.update(self.iv)
+            mac.update(self.iv)
 
         enc_frame = self.read(length)
 

--- a/signal_backup_file.py
+++ b/signal_backup_file.py
@@ -10,7 +10,6 @@ from Reactions_pb2 import ReactionList
 
 from Crypto.Cipher import AES
 from Crypto.Hash import SHA512
-from Crypto.Util import strxor
 
 from axolotl.kdf.hkdfv3 import HKDFv3
 


### PR DESCRIPTION
So, after my last patch, I was wondering a bit about the speed of this program. When I wrote the patch I mostly used some of my small testbackups, but when I was done I also threw my actual current backup at it and it took a long time 

Assuming pycryptodome uses some fast compiled language under the hood, I was surprised by the performance, but of course, it must be because the file is decrypted 16 bytes at a time. (I did find the 'manual' CTR mode interesting, and honestly it was a learning experience)

This patch uses AES in CTR mode (instead of the current ECB). This enables just passing it full encrypted frames instead of 16-byte chunks. Side effects: because the starting `iv` can't be offset by 4 bytes (for the encrypted length) and the same AES object must be used for the length and the following framedata, the length of the frame needed to be read inside the `read_frame` function.

I am _still_ not a python programmer. Feel free to disregard and/or completely rewrite this patch. Also please test thoroughly, I do not want to mess up your project.

On my system, reading the backups from an SSD (SATA):
```
#OLD (~76MB backup)
[~/temp/SignalBackupParser] $ time python signal_backup_file.py ~/PHONE/DEVsignal-2023-11-23-15-24-09.backup 000000000000000000000000000000
  [####################################]  100%
real    0m10,142s
#NEW (~76MB backup)
[~/temp/SignalBackupParser] $ time python signal_backup_file.py ~/PHONE/DEVsignal-2023-11-23-15-24-09.backup 000000000000000000000000000000
  [####################################]  100%
real    0m0,815s
```
```
#OLD (~6.4GB backup)
[~/temp/SignalBackupParser] $ time python signal_backup_file.py ~/PHONE/signal-2023-11-08-03-50-00.backup [passphrase] 
  [####################################]  100%          
real    13m48,111s
#NEW (~6.4GB backup)
[~/temp/SignalBackupParser] $ time python signal_backup_file.py ~/PHONE/signal-2023-11-08-03-50-00.backup [passphrase] 
  [####################################]  100%          
real    0m20,683s
```

This is a freebee, no charge 😉